### PR TITLE
Default 0 if missing from ME

### DIFF
--- a/src/ME Autocraft/meautocraft.lua
+++ b/src/ME Autocraft/meautocraft.lua
@@ -30,7 +30,11 @@ function checkMe(checkName, name, low)
       print("Failed to locate meItem " .. checkName)
       return
     end
-    size = tostring(meItem.amount)
+    if not meItem.amount then
+        size = 0
+    else
+        size = tostring(meItem.amount)
+    end
     ItemName = meItem.name
     row = row + 1
     CenterT(name, row, colors.black, colors.lightGray, "left", false)


### PR DESCRIPTION
Script errored out if item was entirely not present within the system. Default to zero present if item isn't present.